### PR TITLE
ci(github): Basic Gradle workflow to build on Github

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,5 +16,16 @@ jobs:
         uses: gradle/wrapper-validation-action@v1
       - name: Setup Gradle
         uses: gradle/gradle-build-action@v2
-      - name: Execute Gradle Build
-        run: ./gradlew build
+      - name: Build Distribution for Launcher
+        run: ./gradlew distForLauncher
+      - name: Unit Tests
+        run: ./gradlew unitTest
+      - name: Integration Tests
+        run: ./gradlew integrationTest
+      - name: Static Code Analysis
+        run: ./gradlew check -x test
+      - name: API Documentation
+        run: ./gradlew javadoc
+      - name: Publish
+        run: echo "TODO"
+        

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,20 @@
+name: Java CI
+
+on: [push]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up JDK
+        uses: actions/setup-java@v3
+        with:
+          java-version: '15'
+          distribution: 'adopt'
+      - name: Validate Gradle Wrapper
+        uses: gradle/wrapper-validation-action@v1
+      - name: Setup Gradle
+        uses: gradle/gradle-build-action@v2
+      - name: Execute Gradle Build
+        run: ./gradlew build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v3
         with:
-          java-version: '15'
+          java-version: '11'
           distribution: 'adopt'
       - name: Validate Gradle Wrapper
         uses: gradle/wrapper-validation-action@v1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,4 +54,19 @@ jobs:
         uses: gradle/gradle-build-action@v2      
       - name: Static Code Analysis
         run: ./gradlew check -x test
+  build-with-scan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up JDK
+        uses: actions/setup-java@v3
+        with:
+          java-version: '11'
+          distribution: 'adopt'
+      - name: Validate Gradle Wrapper
+        uses: gradle/wrapper-validation-action@v1
+      - name: Setup Gradle
+        uses: gradle/gradle-build-action@v2
+      - name: Build With Gradlew
+        run: ./gradlew build --scan
         

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -68,5 +68,5 @@ jobs:
       - name: Setup Gradle
         uses: gradle/gradle-build-action@v2
       - name: Build With Gradlew
-        run: ./gradlew build --scan
+        run: ./gradlew -PacceptGradleBuildScanTermsOfService=yes distForLauncher --scan
         

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,12 +20,38 @@ jobs:
         run: ./gradlew distForLauncher
       - name: Unit Tests
         run: ./gradlew unitTest
-      - name: Integration Tests
-        run: ./gradlew integrationTest
-      - name: Static Code Analysis
-        run: ./gradlew check -x test
       - name: API Documentation
         run: ./gradlew javadoc
       - name: Publish
         run: echo "TODO"
+  integration-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up JDK
+        uses: actions/setup-java@v3
+        with:
+          java-version: '11'
+          distribution: 'adopt'
+      - name: Validate Gradle Wrapper
+        uses: gradle/wrapper-validation-action@v1
+      - name: Setup Gradle
+        uses: gradle/gradle-build-action@v2      
+      - name: Integration Tests
+        run: ./gradlew integrationTest
+  code-analysis:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up JDK
+        uses: actions/setup-java@v3
+        with:
+          java-version: '11'
+          distribution: 'adopt'
+      - name: Validate Gradle Wrapper
+        uses: gradle/wrapper-validation-action@v1
+      - name: Setup Gradle
+        uses: gradle/gradle-build-action@v2      
+      - name: Static Code Analysis
+        run: ./gradlew check -x test
         

--- a/build-logic/src/main/kotlin/terasology-metrics.gradle.kts
+++ b/build-logic/src/main/kotlin/terasology-metrics.gradle.kts
@@ -45,7 +45,7 @@ tasks.withType<Test> {
     useJUnitPlatform()
 
     // ignoreFailures: Specifies whether the build should break when the verifications performed by this task fail.
-    ignoreFailures = true
+    ignoreFailures = false
     // showStandardStreams: makes the standard streams (err and out) visible at console when running tests
     // If false, the outputs are still collected and visible in the test report, but they don't spam the console.
     testLogging.showStandardStreams = false

--- a/build.gradle
+++ b/build.gradle
@@ -282,3 +282,15 @@ idea {
 cleanIdea.doLast {
     new File('Terasology.iws').delete()
 }
+
+if (hasProperty('buildScan')
+        // allow to programmically accept the Gradle Build Scan terms of service when running in CI
+        && project.hasProperty('acceptGradleBuildScanTermsOfService') 
+        && project.acceptGradleBuildScanTermsOfService == 'yes') {
+    gradleEnterprise {
+        buildScan {
+            termsOfServiceUrl = "https://gradle.com/terms-of-service"
+            termsOfServiceAgree = "yes"
+        }
+    }
+}


### PR DESCRIPTION
### Contains

A Github workflow to build, test, and analyze the code.

Uses Gradle Build Scans for reporting, see https://docs.gradle.com/enterprise/gradle-plugin/#connecting_to_scans_gradle_com (automatically accepted for CI runs, but no for local runs).

### How to test

- [ ] ensure that `gradlew distForLauncher --scan` still prompts for user agreement
- [ ] ensure that the jobs look reasonable and work correctly (for instance, :x: when build should be failing)

### Additional Tasks

- [ ] configure mandatory checks to use Github jobs instead of Jenkins jobs for now
